### PR TITLE
Update pcrclient.py

### DIFF
--- a/pcrclient.py
+++ b/pcrclient.py
@@ -45,8 +45,8 @@ def _set_version(version: str):
 defaultHeaders = {
     'Accept-Encoding': 'gzip',
     'User-Agent': 'Dalvik/2.1.0 (Linux, U, Android 5.1.1, PCRT00 Build/LMY48Z)',
-    'X-Unity-Version': '2018.4.30f1',
-    'APP-VER': "4.9.9",
+    'X-Unity-Version': '2021.3.20f1c11',
+    'APP-VER': "11.7.1",
     'BATTLE-LOGIC-VERSION': '4',
     'BUNDLE-VER': '',
     'DEVICE': '2',
@@ -96,24 +96,24 @@ class pcrclient:
 
     @staticmethod
     def pack(data: object, key: bytes) -> bytes:
-        aes = AES.new(key, AES.MODE_CBC, b'ha4nBYA2APUD6Uv1')
+        aes = AES.new(key, AES.MODE_CBC, b'7Fk9Lm3Np8Qr4Sv2')
         return aes.encrypt(pcrclient.add_to_16(packb(data, use_bin_type=False))) + key
 
     @staticmethod
     def encrypt(data: str, key: bytes) -> bytes:
-        aes = AES.new(key, AES.MODE_CBC, b'ha4nBYA2APUD6Uv1')
+        aes = AES.new(key, AES.MODE_CBC, b'7Fk9Lm3Np8Qr4Sv2')
         return aes.encrypt(pcrclient.add_to_16(data.encode('utf8'))) + key
 
     @staticmethod
     def decrypt(data: bytes):
         data = b64decode(data.decode('utf8'))
-        aes = AES.new(data[-32:], AES.MODE_CBC, b'ha4nBYA2APUD6Uv1')
+        aes = AES.new(data[-32:], AES.MODE_CBC, b'7Fk9Lm3Np8Qr4Sv2')
         return aes.decrypt(data[:-32]), data[-32:]
 
     @staticmethod
     def unpack(data: bytes):
         data = b64decode(data.decode('utf8'))
-        aes = AES.new(data[-32:], AES.MODE_CBC, b'ha4nBYA2APUD6Uv1')
+        aes = AES.new(data[-32:], AES.MODE_CBC, b'7Fk9Lm3Np8Qr4Sv2')
         dec = aes.decrypt(data[:-32])
         return unpackb(dec[:-dec[-1]], strict_map_key=False), data[-32:]
 
@@ -194,3 +194,4 @@ class pcrclient:
         await self.check_gamestart()
 
         # await self.callapi('/check/check_agreement', {})
+


### PR DESCRIPTION
更改客户端版本与加密

## Summary by Sourcery

Update PCR client version headers and rotate AES encryption IV across pack, encrypt, decrypt, and unpack methods.

Enhancements:
- Bump X-Unity-Version to 2021.3.20f1c11 and APP-VER to 11.7.1
- Replace hardcoded AES CBC initialization vector in encryption/decryption routines